### PR TITLE
Update README.md: compose replaced with pipe to keep examples consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,8 +82,8 @@ Function composition has been used for years, even in JS applications. It's one 
 There's also the [numerous npm modules](https://www.npmjs.com/search?q=function+composition) and manual implementations (it's trivial to write a basic implementation). Conceptually, it's pretty basic:
 
 ```js
-function compose(f, g) {
-    return (...xs) => f(g(...xs))
+function pipe(f, g) {
+    return (...xs) => g(f(...xs))
 }
 ```
 
@@ -107,7 +107,7 @@ const toSlug = [
     _ => _.map(str => str.toLowerCase()),
     _ => _.join("-"),
     encodeURIComponent,
-].reduce(compose)
+].reduce(pipe)
 ```
 
 Or, using this proposal:


### PR DESCRIPTION
Small fix in README. 

Application order of `compose`-result is opposite to the order of argument functions.
So `compose` in some samples should be replaced with `pipe` function that keeps application order (what is also preserved by `:>` operator).

Consider playground: https://codesandbox.io/s/pipe-vs-compose-92k2l?expanddevtools=1&fontsize=14&moduleview=1&theme=dark